### PR TITLE
gx: update go-testutil

### DIFF
--- a/.gx/lastpubver
+++ b/.gx/lastpubver
@@ -1,1 +1,1 @@
-1.3.16: QmRNyPNJGNCaZyYonJj7owciWTsMd9gRfEKmZY3o6xwN3h
+1.3.17: Qmeqtv7ASvepCpUDxysK2oP1urtEr5eMNMxbhTJYJziAGo

--- a/package.json
+++ b/package.json
@@ -39,9 +39,9 @@
     },
     {
       "author": "whyrusleeping",
-      "hash": "QmUKtSzfnSfSWz9rVXcReqJbBkUFbD9W4Aq6zannqxVc4T",
+      "hash": "QmZg566m6GTANKnweD63nLao2J5qgFVSKscHqrNyVUzwDA",
       "name": "go-libp2p-connmgr",
-      "version": "0.1.0"
+      "version": "0.1.1"
     },
     {
       "author": "whyrusleeping",
@@ -61,6 +61,6 @@
   "license": "",
   "name": "go-libp2p-host",
   "releaseCmd": "git commit -a -m \"gx publish $VERSION\"",
-  "version": "1.3.16"
+  "version": "1.3.17"
 }
 


### PR DESCRIPTION
Depends on:

- https://github.com/libp2p/go-libp2p-conn/pull/11
- https://github.com/libp2p/go-libp2p-connmgr/pull/2


This PR with gx updates has been created using gx-workspace: https://github.com/ipfs/gx-workspace