### PR TITLE
Helper to get PeerInfo from Host

### DIFF
--- a/helpers.go
+++ b/helpers.go
@@ -1,0 +1,11 @@
+package host
+
+import pstore "github.com/libp2p/go-libp2p-peerstore"
+
+// PeerInfoFromHost returns a PeerInfo struct with the Host's ID and all of its Addrs.
+func PeerInfoFromHost(h Host) *pstore.PeerInfo {
+	return &pstore.PeerInfo{
+		ID:    h.ID(),
+		Addrs: h.Addrs(),
+	}
+}


### PR DESCRIPTION
Trivial change to make this easier based on [user](https://stackoverflow.com/questions/52933917/how-can-i-get-a-peerinfo-from-a-host) [feedback](https://twitter.com/LouisThibault87/status/1054487791587999746).

go-libp2p-host already imports the go-libp2p-peerstore, so no strings attached.