### PR TITLE
Update go-semver

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,7 @@
 module github.com/libp2p/go-libp2p-host
 
 require (
-	github.com/coreos/go-semver v0.2.0
+	github.com/coreos/go-semver v0.2.1-0.20180108230905-e214231b295a
 	github.com/libp2p/go-libp2p-interface-connmgr v0.0.1
 	github.com/libp2p/go-libp2p-net v0.0.1
 	github.com/libp2p/go-libp2p-peer v0.0.1

--- a/go.sum
+++ b/go.sum
@@ -12,6 +12,8 @@ github.com/btcsuite/websocket v0.0.0-20150119174127-31079b680792/go.mod h1:ghJtE
 github.com/btcsuite/winsvc v1.0.0/go.mod h1:jsenWakMcC0zFBFurPLEAyrnc/teJEM1O46fmI40EZs=
 github.com/coreos/go-semver v0.2.0 h1:3Jm3tLmsgAYcjC+4Up7hJrFBPr+n7rAqYeSw/SZazuY=
 github.com/coreos/go-semver v0.2.0/go.mod h1:nnelYz7RCh+5ahJtPPxZlU+153eP4D4r3EedlOD2RNk=
+github.com/coreos/go-semver v0.2.1-0.20180108230905-e214231b295a h1:U0BbGfKnviqVBJQB4etvm+mKx53KfkumNLBt6YeF/0Q=
+github.com/coreos/go-semver v0.2.1-0.20180108230905-e214231b295a/go.mod h1:nnelYz7RCh+5ahJtPPxZlU+153eP4D4r3EedlOD2RNk=
 github.com/davecgh/go-spew v0.0.0-20171005155431-ecdeabc65495/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=


### PR DESCRIPTION
The current release version fails tests.
```
$ vgo test all -failfast
ok  	bufio	0.059s
ok  	bytes	2.564s
ok  	compress/bzip2	0.077s
# github.com/coreos/go-semver/semver
../../../../pkg/mod/github.com/coreos/go-semver@v0.2.0/semver/semver_test.go:179:5: redundant and: version.PreRelease != "" && version.PreRelease != ""

$ vgo mod why github.com/coreos/go-semver/semver
# github.com/coreos/go-semver/semver
github.com/libp2p/go-libp2p-host
github.com/coreos/go-semver/semver
```
